### PR TITLE
修复 Target IBM Cloud 中 多个space选择问题

### DIFF
--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -39,4 +39,4 @@ jobs:
       env:
         IBM_APP_NAME: ${{ secrets.IBM_APP_NAME }}
       run: |
-        ./IBM_Cloud_CLI/ibmcloud cf restart "$IBM_APP_NAME"
+        ./IBM_Cloud_CLI/ibmcloud cf restart "$IBM_APP_NAME" 

--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Target IBM Cloud
       env:
         RESOURSE_ID: ${{ secrets.RESOURSE_ID }}
+        IBM_SPACE_NAME: ${{ secrets.IBM_SPACE_NAME }}
       run: |
         ./IBM_Cloud_CLI/ibmcloud target -s "$IBM_SPACE_NAME" -g "$RESOURSE_ID"
         ./IBM_Cloud_CLI/ibmcloud target --cf

--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -33,10 +33,10 @@ jobs:
         RESOURSE_ID: ${{ secrets.RESOURSE_ID }}
       run: |
         ./IBM_Cloud_CLI/ibmcloud target -g "$RESOURSE_ID"
-        ./IBM_Cloud_CLI/ibmcloud target --cf
+        ./IBM_Cloud_CLI/ibmcloud target -s "$IBM_SPACE_NAME" --cf
         ./IBM_Cloud_CLI/ibmcloud cf install
     - name: Restart IBM Cloud
       env:
         IBM_APP_NAME: ${{ secrets.IBM_APP_NAME }}
       run: |
-        ./IBM_Cloud_CLI/ibmcloud cf restart "$IBM_APP_NAME" 
+        ./IBM_Cloud_CLI/ibmcloud cf restart "$IBM_APP_NAME"

--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -33,8 +33,8 @@ jobs:
         RESOURSE_ID: ${{ secrets.RESOURSE_ID }}
         IBM_SPACE_NAME: ${{ secrets.IBM_SPACE_NAME }}
       run: |
-        ./IBM_Cloud_CLI/ibmcloud target -s "$IBM_SPACE_NAME" -g "$RESOURSE_ID"
-        ./IBM_Cloud_CLI/ibmcloud target --cf
+        ./IBM_Cloud_CLI/ibmcloud target -g "$RESOURSE_ID"
+        ./IBM_Cloud_CLI/ibmcloud target -s "$IBM_SPACE_NAME" --cf
         ./IBM_Cloud_CLI/ibmcloud cf install
     - name: Restart IBM Cloud
       env:

--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -32,8 +32,8 @@ jobs:
       env:
         RESOURSE_ID: ${{ secrets.RESOURSE_ID }}
       run: |
-        ./IBM_Cloud_CLI/ibmcloud target -g "$RESOURSE_ID"
-        ./IBM_Cloud_CLI/ibmcloud target -s "$IBM_SPACE_NAME" --cf
+        ./IBM_Cloud_CLI/ibmcloud target -s "$IBM_SPACE_NAME" -g "$RESOURSE_ID"
+        ./IBM_Cloud_CLI/ibmcloud target --cf
         ./IBM_Cloud_CLI/ibmcloud cf install
     - name: Restart IBM Cloud
       env:

--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ https://github.com/CCChieh/IBMYes
 
 New secret
 
-分别建立四个secret
+分别建立五个secret
 
 ```
 IBM_ACCOUNT // IBM Cloud的登录邮箱和密码
 IBM_APP_NAME // 应用的名称
+IBM_SPACE_NAME //应用所属空间的名称
 REGION_NUM // 区域编码
 RESOURSE_ID // 资源组ID
 ```


### PR DESCRIPTION
通过添加新变量IBM_SPACE_NAME来指定space名称即可

报错如下：
```
Targeted org ***

FAILED

Could not get space:
Select a space (or press enter to skip):
1. ***
2. test
Enter a number> 
Could not read from input: EOF

##[error]Process completed with exit code 1.
```