### PR TITLE
IBM Cloud CLI v 6.52.0 'No API endpoint set' bug work-around

### DIFF
--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         ./IBM_Cloud_CLI/ibmcloud target -g "$RESOURSE_ID"
         ./IBM_Cloud_CLI/ibmcloud target --cf
-        ./IBM_Cloud_CLI/ibmcloud cf install
+        ./IBM_Cloud_CLI/ibmcloud cf install -v 6.51.0
     - name: Restart IBM Cloud
       env:
         IBM_APP_NAME: ${{ secrets.IBM_APP_NAME }}


### PR DESCRIPTION
IBM Cloud CLI v 6.52.0 'No API endpoint set' bug work-around